### PR TITLE
Only call callback once when outputting multiple files

### DIFF
--- a/index.js
+++ b/index.js
@@ -113,9 +113,6 @@ ProtobufPlugin.prototype.singleOutput = function (files, cb) {
 };
 
 ProtobufPlugin.prototype.multipleOutput = function (files, cb) {
-    if (files.length === 0) {
-        cb();
-    }
     var promise = [];
     var self = this;
     var root = path.relative(process.cwd(), this.options.output);


### PR DESCRIPTION
`Promise.all(promise)` will return an already resolved Promise if the iterable passed is empty. This extra is empty check with the early callback call will cause the callback to be called twice and fail with an obscure error such as "No such label 'emitAssets' for WebpackLogger.timeEnd()"