### PR TITLE
Add support for output file customisation

### DIFF
--- a/index.js
+++ b/index.js
@@ -118,8 +118,6 @@ ProtobufPlugin.prototype.multipleOutput = function (files, cb) {
     }
     var promise = [];
     var self = this;
-    var root = path.relative(process.cwd(), this.options.output);
-    mkdir.sync(root);
     files.forEach(function (file) {
         promise.push(new Promise(function (resolve, reject) {
             let command = [].concat(self.command);
@@ -141,7 +139,13 @@ ProtobufPlugin.prototype.multipleOutput = function (files, cb) {
         res.forEach(function (result) {
             var output = result.output;
             var file = result.file;
-            var outputPath = path.join(self.options.output, path.parse(file).name + '.js');
+            var outputPath;
+            if (typeof self.options.output === 'function') {
+                outputPath = self.options.output(file);
+            } else {
+                outputPath = path.join(self.options.output, path.parse(file).name + '.js');
+            }
+            mkdir.sync(path.parse(outputPath).dir);
             fs.writeFile(outputPath, output, function (error) {
                 if (error) {
                     console.log('[protobuf plugin] output error: ', error);


### PR DESCRIPTION
This allows the following:
```
    new ProtobufPlugin({
      input: '../proto/src/main/protobuf/shared/**/*.proto',
      output: (file) => {
        const relative = path.relative('../proto/src/main/protobuf', file)
        const parsed = path.parse(relative)
        return path.join('protobuf', parsed.dir, parsed.name + '.js')
      },
      outputType: 1
    )}